### PR TITLE
Adjust KYC response to correctly represent certification history list

### DIFF
--- a/SilaSDK/pom.xml
+++ b/SilaSDK/pom.xml
@@ -3,7 +3,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.icon.sila</groupId>
     <artifactId>icon-sila-sdk</artifactId>
-    <version>1.47-SNAPSHOT</version>
+    <version>1.47</version>
     <packaging>jar</packaging>
 
     <name>Icon Sila SDK</name>
@@ -27,7 +27,7 @@
       <connection>scm:git:git@github.com:icon-savings/sila-sdk-java.git</connection>
       <developerConnection>scm:git:git@github.com:icon-savings/sila-sdk-java.git</developerConnection>
       <url>https://github.com/icon-savings/sila-sdk-java</url>
-      <tag>v1.41</tag>
+      <tag>v1.47</tag>
     </scm>
 
     <properties>

--- a/SilaSDK/pom.xml
+++ b/SilaSDK/pom.xml
@@ -3,7 +3,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.icon.sila</groupId>
     <artifactId>icon-sila-sdk</artifactId>
-    <version>1.47</version>
+    <version>1.48-SNAPSHOT</version>
     <packaging>jar</packaging>
 
     <name>Icon Sila SDK</name>
@@ -27,7 +27,7 @@
       <connection>scm:git:git@github.com:icon-savings/sila-sdk-java.git</connection>
       <developerConnection>scm:git:git@github.com:icon-savings/sila-sdk-java.git</developerConnection>
       <url>https://github.com/icon-savings/sila-sdk-java</url>
-      <tag>v1.47</tag>
+      <tag>v1.41</tag>
     </scm>
 
     <properties>

--- a/SilaSDK/src/main/java/com/silamoney/client/domain/CheckKYCResponse.java
+++ b/SilaSDK/src/main/java/com/silamoney/client/domain/CheckKYCResponse.java
@@ -16,8 +16,10 @@ public class CheckKYCResponse extends BaseResponse {
     private List<String> validKycLevels;
     @SerializedName(value = "certification_status")
     private String certificationStatus;
+    // The official Sila SDK has this as a list of Strings, but that is wrong.
+    // If we rebase in any SDK updates we need to maintain this as a list of Certification objects.
     @SerializedName(value = "certification_history")
-    private List<String> certificationHistory;
+    private List<Certification> certificationHistory;
     private List<Member> members;
 
     /**
@@ -93,14 +95,14 @@ public class CheckKYCResponse extends BaseResponse {
     /**
      * @return the certificationHistory
      */
-    public List<String> getCertificationHistory() {
+    public List<Certification> getCertificationHistory() {
         return certificationHistory;
     }
 
     /**
      * @param certificationHistory the certificationHistory to set
      */
-    public void setCertificationHistory(List<String> certificationHistory) {
+    public void setCertificationHistory(List<Certification> certificationHistory) {
         this.certificationHistory = certificationHistory;
     }
 


### PR DESCRIPTION
Two years ago we patched the fact that the Sila SDK wrongly has certificationHistory on the CheckKYCResponse object as a List<String>, but that patch was overwritten on the recent fork cleanup. This repatches the issue and adds a code comment which will hopefully prevent us from doing the same thing again.