### PR TITLE
fix: ICON-1192 handle http error codes

### DIFF
--- a/SilaSDK/pom.xml
+++ b/SilaSDK/pom.xml
@@ -3,7 +3,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.icon.sila</groupId>
     <artifactId>icon-sila-sdk</artifactId>
-    <version>1.48-SNAPSHOT</version>
+    <version>1.48</version>
     <packaging>jar</packaging>
 
     <name>Icon Sila SDK</name>
@@ -27,7 +27,7 @@
       <connection>scm:git:git@github.com:icon-savings/sila-sdk-java.git</connection>
       <developerConnection>scm:git:git@github.com:icon-savings/sila-sdk-java.git</developerConnection>
       <url>https://github.com/icon-savings/sila-sdk-java</url>
-      <tag>v1.41</tag>
+      <tag>v1.48</tag>
     </scm>
 
     <properties>

--- a/SilaSDK/pom.xml
+++ b/SilaSDK/pom.xml
@@ -3,7 +3,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.icon.sila</groupId>
     <artifactId>icon-sila-sdk</artifactId>
-    <version>1.48</version>
+    <version>1.49-SNAPSHOT</version>
     <packaging>jar</packaging>
 
     <name>Icon Sila SDK</name>
@@ -27,7 +27,7 @@
       <connection>scm:git:git@github.com:icon-savings/sila-sdk-java.git</connection>
       <developerConnection>scm:git:git@github.com:icon-savings/sila-sdk-java.git</developerConnection>
       <url>https://github.com/icon-savings/sila-sdk-java</url>
-      <tag>v1.48</tag>
+      <tag>v1.41</tag>
     </scm>
 
     <properties>

--- a/SilaSDK/src/main/java/com/silamoney/client/util/ResponseUtil.java
+++ b/SilaSDK/src/main/java/com/silamoney/client/util/ResponseUtil.java
@@ -105,6 +105,13 @@ public class ResponseUtil {
             success = false;
         }
         try {
+            if (statusCode >= 500) {
+                logger.get().log(Level.SEVERE, Map.of("message", statusMessage(statusCode),
+                        "statusCode", response.statusCode(),
+                        "responseBody", bodyString,
+                        "responseMessage", msg));
+                throw new ApiError(response.statusCode(), statusMessage(statusCode), bodyString);
+            }
             if (statusCode == 400) {
                 BadRequestResponse badRequestResponse = (BadRequestResponse) Serialization
                         .deserialize(bodyString, BadRequestResponse.class);
@@ -426,6 +433,14 @@ public class ResponseUtil {
                     "responseMessage", msg));
             throw new ApiError(response.statusCode(), ex.getMessage(), bodyString);
         }
+    }
+
+    private static String statusMessage(int statusCode) {
+        Map<Integer, String> statusMessages = Map.of(500, "Internal server error",
+                502, "Bad Gateway",
+                503, "Service Unavailable",
+                504, "Gateway Timeout");
+        return statusMessages.getOrDefault(statusCode, "Unknown error");
     }
 
 


### PR DESCRIPTION
## Context
The 50X error codes cannot be converted into a Response object, they should be bubbled up as errors

```
{
    "output": {
        "error": {
            "message": "class com.silamoney.client.domain.GetTransactionsResponse cannot be cast to class com.silamoney.client.domain.BaseResponse (com.silamoney.client.domain.GetTransactionsResponse and com.silamoney.client.domain.BaseResponse are in unnamed module of loader 'app')",
            "stackTrace": [
                {
....
```
## Related Issue

ICON-1192

## Testing

Brief summary of what/where/how to test - what page in the frontend, what route in the API, workflows etc. 


**Before You Merge**
- [ ] Merge most recent sha of master into your feature branch, then verify migration filenames are unique
- [ ] Add new environment variables to staging and production in heroku
- [ ] Notify the team of any new environment variables that are necessary for running the service locally

**Checklist**
- [ ] Updated procfile (if needed)
