### PR TITLE
fix: ICON-5505 sila reference

### DIFF
--- a/SilaSDK/pom.xml
+++ b/SilaSDK/pom.xml
@@ -3,7 +3,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.icon.sila</groupId>
     <artifactId>icon-sila-sdk</artifactId>
-    <version>1.54</version>
+    <version>1.55-SNAPSHOT</version>
     <packaging>jar</packaging>
 
     <name>Icon Sila SDK</name>
@@ -27,7 +27,7 @@
       <connection>scm:git:git@github.com:icon-savings/sila-sdk-java.git</connection>
       <developerConnection>scm:git:git@github.com:icon-savings/sila-sdk-java.git</developerConnection>
       <url>https://github.com/icon-savings/sila-sdk-java</url>
-      <tag>v1.54</tag>
+      <tag>v1.41</tag>
     </scm>
 
     <properties>

--- a/SilaSDK/pom.xml
+++ b/SilaSDK/pom.xml
@@ -3,7 +3,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.icon.sila</groupId>
     <artifactId>icon-sila-sdk</artifactId>
-    <version>1.54-SNAPSHOT</version>
+    <version>1.54</version>
     <packaging>jar</packaging>
 
     <name>Icon Sila SDK</name>
@@ -27,7 +27,7 @@
       <connection>scm:git:git@github.com:icon-savings/sila-sdk-java.git</connection>
       <developerConnection>scm:git:git@github.com:icon-savings/sila-sdk-java.git</developerConnection>
       <url>https://github.com/icon-savings/sila-sdk-java</url>
-      <tag>v1.41</tag>
+      <tag>v1.54</tag>
     </scm>
 
     <properties>

--- a/SilaSDK/src/main/java/com/silamoney/client/domain/BaseResponse.java
+++ b/SilaSDK/src/main/java/com/silamoney/client/domain/BaseResponse.java
@@ -28,4 +28,9 @@ public class BaseResponse {
     @SerializedName("response_time_ms")
     public String responseTimeMs;
 
+    @Getter
+    @SerializedName("sila_reference_id")
+    private String silaReferenceId;
+
+
 }

--- a/SilaSDK/src/main/java/com/silamoney/client/domain/GetWalletResponse.java
+++ b/SilaSDK/src/main/java/com/silamoney/client/domain/GetWalletResponse.java
@@ -33,7 +33,4 @@ public class GetWalletResponse extends BaseResponse {
     @SerializedName("sila_pending_balance")
     private double silaPendingBalance;
 
-    @Getter
-    @SerializedName("sila_reference_id")
-    private String silaReferenceId;
 }


### PR DESCRIPTION
`sila_reference_id` field is on all responses, so should be in the base class.