### PR TITLE
fix: ICON-13495 Missed return 

### DIFF
--- a/SilaSDK/pom.xml
+++ b/SilaSDK/pom.xml
@@ -3,7 +3,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.icon.sila</groupId>
     <artifactId>icon-sila-sdk</artifactId>
-    <version>1.65</version>
+    <version>1.66-SNAPSHOT</version>
     <packaging>jar</packaging>
 
     <name>Icon Sila SDK</name>
@@ -27,7 +27,7 @@
       <connection>scm:git:git@github.com:icon-savings/sila-sdk-java.git</connection>
       <developerConnection>scm:git:git@github.com:icon-savings/sila-sdk-java.git</developerConnection>
       <url>https://github.com/icon-savings/sila-sdk-java</url>
-      <tag>v1.65</tag>
+      <tag>v1.63</tag>
     </scm>
 
     <properties>

--- a/SilaSDK/pom.xml
+++ b/SilaSDK/pom.xml
@@ -3,7 +3,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.icon.sila</groupId>
     <artifactId>icon-sila-sdk</artifactId>
-    <version>1.65-SNAPSHOT</version>
+    <version>1.65</version>
     <packaging>jar</packaging>
 
     <name>Icon Sila SDK</name>
@@ -27,7 +27,7 @@
       <connection>scm:git:git@github.com:icon-savings/sila-sdk-java.git</connection>
       <developerConnection>scm:git:git@github.com:icon-savings/sila-sdk-java.git</developerConnection>
       <url>https://github.com/icon-savings/sila-sdk-java</url>
-      <tag>v1.63</tag>
+      <tag>v1.65</tag>
     </scm>
 
     <properties>

--- a/SilaSDK/src/main/java/com/silamoney/client/util/ResponseUtil.java
+++ b/SilaSDK/src/main/java/com/silamoney/client/util/ResponseUtil.java
@@ -254,6 +254,7 @@ public class ResponseUtil {
                 case "get_verifications":
                     GetVerificationsResponse getVerificationsResponse = (GetVerificationsResponse) Serialization
                             .deserialize(bodyString, GetVerificationsResponse.class);
+                    return new ApiResponse(statusCode, response.headers().map(), getVerificationsResponse, success);
 
                 case "get_verification":
                     GetVerificationResponse getVerificationResponse = (GetVerificationResponse) Serialization


### PR DESCRIPTION
```
 "message": "class com.silamoney.client.domain.GetVerificationResponse cannot be cast to class com.silamoney.client.domain.GetVerificationsResponse (com.silamoney.client.domain.GetVerificationResponse and com.silamoney.client.domain.GetVerificationsResponse are in unnamed module of loader 'app')",
            "suppressed": [],
            "localizedMessage": "class com.silamoney.client.domain.GetVerificationResponse cannot be cast to class com.silamoney.client.domain.GetVerificationsResponse (com.silamoney.client.domain.GetVerificationResponse and com.silamoney.client.domain.GetVerificationsResponse are in unnamed module of loader 'app')"
        },
```